### PR TITLE
Add child posts API

### DIFF
--- a/migrations/20190420083749-posts.js
+++ b/migrations/20190420083749-posts.js
@@ -48,6 +48,20 @@ exports.up = function (db) {
           mapping: 'id',
         },
       },
+      parent: {
+        type: 'string',
+        length: '64',
+        null: true,
+        foreignKey: {
+          name: 'post_parent_id_fk',
+          table: 'posts',
+          rules: {
+            onDelete: 'CASCADE',
+            onUpdate: 'RESTRICT',
+          },
+          mapping: 'id',
+        },
+      },
       created: {
         type: 'string',
         length: 64,

--- a/server/controllers/postController.js
+++ b/server/controllers/postController.js
@@ -34,7 +34,9 @@ postController.getPosts = (req, res) => {
  * Handler for returning one post
  */
 postController.getPost = (req, res) => {
-  getPostHandler(req.params.id, (status = 200, data) => {
+  const depth = Number(req.query.depth) || 0;
+  const limit = Number(req.query.limit) || 3;
+  getPostHandler(req.params.id, depth, limit, (status = 200, data) => {
     if (req.post === data.postname) {
       res.status(status).json(data).end();
     } else {


### PR DESCRIPTION
Modify the API endpoints to:
- add post as a child (reply) of another post.
- Add limit and depth option for `getPost` API so that we can get child posts